### PR TITLE
Update with new ComCat API url.

### DIFF
--- a/LoadComCat.m
+++ b/LoadComCat.m
@@ -36,7 +36,7 @@ end
   
 
 % URL for ComCat "count" method
-url='http://comcat.cr.usgs.gov/fdsnws/event/1/count';
+url='http://earthquake.usgs.gov/fdsnws/event/1/count';
 clear params;
 params{1}='starttime'; params{3}= 'endtime'; 
 params{5}='minmagnitude';  params{6}= num2str(minMagnitude);
@@ -83,7 +83,7 @@ end
 % Now batch load catalogs!
 
 % URL for ComCat "query" method
-url='http://comcat.cr.usgs.gov/fdsnws/event/1/query';
+url='http://earthquake.usgs.gov/fdsnws/event/1/query';
 params{end+1}='format'; params{end+1}='csv';
 params{end+1}='orderby'; params{end+1}='time-asc';
   


### PR DESCRIPTION
Edits to accommodate url change for ComCat API searches from 
http://comcat.cr.usgs.gov/fdsnws/event/1/ 
to 
http://earthquake.usgs.gov/fdsnws/event/1